### PR TITLE
Update tcp_client.cpp

### DIFF
--- a/src/tcp_client.cpp
+++ b/src/tcp_client.cpp
@@ -104,6 +104,7 @@ void TcpClient::ReceiveTask() {
 
     while(!stop) {
         char msg[MAX_PACKET_SIZE];
+        memset(msg, 0, sizeof msg);
         int numOfBytesReceived = recv(m_sockfd, msg, MAX_PACKET_SIZE, 0);
         if(numOfBytesReceived < 1) {
             pipe_ret_t ret;


### PR DESCRIPTION
For a reason I don't really understand, the msg buffer doesn't seem to get empty at the end of the loop. (The end of a long message can be read on the next shorter message received from the same socket). The memset function allows to empty the buffer before reusing it.